### PR TITLE
Update schedule layout

### DIFF
--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -1,25 +1,40 @@
 {% extends "base.html" %}
 {% block content %}
+  <style>
+    .container {
+      max-width: 1500px;
+    }
+    .schedule-table select {
+      width: 150px;
+    }
+  </style>
   <h2>Schedule</h2>
-  <table>
+  <table class="schedule-table">
     <thead>
       <tr>
         <th>Station</th>
-        <th>Person</th>
+        <th>Person 1</th>
+        <th>Person 2</th>
+        <th>Person 3</th>
+        <th>Person 4</th>
+        <th>Person 5</th>
+        <th>Person 6</th>
       </tr>
     </thead>
     <tbody>
       {% for station in stations %}
       <tr>
         <td>{{ station }}</td>
+        {% for i in range(6) %}
         <td>
-          <select class="person-select" style="width: 200px;">
+          <select class="person-select">
             <option value="">-- Select --</option>
             {% for name in names %}
               <option value="{{ name }}">{{ name }}</option>
             {% endfor %}
           </select>
         </td>
+        {% endfor %}
       </tr>
       {% endfor %}
     </tbody>
@@ -31,6 +46,30 @@
   <script>
     $(function(){
       $('.person-select').select2();
+
+      function updateOptions() {
+        var selected = [];
+        $('.person-select').each(function(){
+          var val = $(this).val();
+          if (val) {
+            selected.push(val);
+          }
+        });
+        $('.person-select').each(function(){
+          var current = $(this).val();
+          $(this).find('option').prop('disabled', false);
+          var selectEl = this;
+          selected.forEach(function(name){
+            if (name !== current) {
+              $(selectEl).find('option[value="'+name.replace(/"/g,'\\"')+'"]').prop('disabled', true);
+            }
+          });
+          $(this).trigger('change.select2');
+        });
+      }
+
+      $('.person-select').on('change', updateOptions);
+      updateOptions();
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show six dropdowns for each station
- expand schedule page width for better layout
- hide selected names from the remaining dropdowns

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68553e693fe0832f9ff86a35802cbaa3