### PR TITLE
Implement generated schedule page

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, request, jsonify, redirect, url_for
+from flask import Flask, render_template, request, jsonify, redirect, url_for, session
 import openpyxl
 import os
 
@@ -50,6 +50,7 @@ def load_workbook_data():
 
 
 app = Flask(__name__)
+app.secret_key = "dev"
 
 @app.route("/")
 def index():
@@ -126,6 +127,28 @@ def schedule():
     _, _, _, data = load_workbook_data()
     names = sorted(data.keys())
     return render_template("schedule.html", stations=STATIONS, names=names)
+
+
+@app.route("/generate_schedule", methods=["POST"])
+def generate_schedule():
+    """Store the submitted schedule and redirect to view page."""
+    schedule = {}
+    for idx, station in enumerate(STATIONS):
+        people = []
+        for j in range(6):
+            key = f"station{idx}_{j}"
+            people.append(request.form.get(key, ""))
+        schedule[station] = people
+    session['last_schedule'] = schedule
+    return redirect(url_for('view_schedule'))
+
+
+@app.route("/view_schedule")
+def view_schedule():
+    schedule = session.get('last_schedule')
+    if not schedule:
+        return redirect(url_for('schedule'))
+    return render_template("generated_schedule.html", schedule=schedule)
 
 @app.route("/decrease", methods=["GET", "POST"])
 def decrease():

--- a/templates/generated_schedule.html
+++ b/templates/generated_schedule.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+{% block content %}
+  <style>
+    .schedule-table td, .schedule-table th {
+      padding: 8px;
+      text-align: center;
+    }
+    .station-cell {
+      background-color: #cce4ff;
+      font-weight: bold;
+    }
+    .name-cell {
+      background-color: #ffffff;
+    }
+  </style>
+  <h2>Generated Schedule</h2>
+  <table class="schedule-table">
+    <thead>
+      <tr>
+        <th>Station</th>
+        {% for i in range(1,7) %}<th>Person {{ i }}</th>{% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for station, people in schedule.items() %}
+      <tr>
+        <td class="station-cell">{{ station }}</td>
+        {% for person in people %}
+        <td class="name-cell">{{ person }}</td>
+        {% endfor %}
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <p style="margin-top:1em;">
+    <a href="{{ url_for('schedule') }}">Back to Schedule Page</a> |
+    <a href="{{ url_for('view_schedule') }}">Reload Generated Schedule</a>
+  </p>
+{% endblock %}

--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -9,6 +9,10 @@
     }
   </style>
   <h2>Schedule</h2>
+  {% if session.get('last_schedule') %}
+    <p><a href="{{ url_for('view_schedule') }}">View Current Generated Schedule</a></p>
+  {% endif %}
+  <form id="scheduleForm" method="post" action="{{ url_for('generate_schedule') }}">
   <table class="schedule-table">
     <thead>
       <tr>
@@ -27,7 +31,7 @@
         <td>{{ station }}</td>
         {% for i in range(6) %}
         <td>
-          <select class="person-select">
+          <select class="person-select" name="station{{ loop.parent.loop.index0 }}_{{ i }}">
             <option value="">-- Select --</option>
             {% for name in names %}
               <option value="{{ name }}">{{ name }}</option>
@@ -39,6 +43,8 @@
       {% endfor %}
     </tbody>
   </table>
+  <p style="margin-top:1em;"><a href="#" id="generateLink">Generate Schedule</a></p>
+  </form>
 
   <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
   <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
@@ -70,6 +76,11 @@
 
       $('.person-select').on('change', updateOptions);
       updateOptions();
+
+      $('#generateLink').on('click', function(e){
+        e.preventDefault();
+        $('#scheduleForm').submit();
+      });
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add link on schedule page to view current schedule or submit selections
- create route to store schedule and display it later
- style generated schedule table with colored cells

## Testing
- `python -m py_compile app.py`
- `flake8` *(fails: command not found)*
- `python app.py` *(started then terminated)*

------
https://chatgpt.com/codex/tasks/task_e_685540cda6d8832fb3b24169535fb7f0