### PR TITLE
Add schedule color coding

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,17 @@ STATIONS = [
     "H567 Ext Bonder", "Driver Assignment", "PC Assignment", "Common Load",
 ]
 
+# map schedule stations to training columns in the spreadsheet
+STATION_TO_HEADER = {
+    "JT Bonder 1": "JT Bonder",
+    "JT Bonder 2": "JT Bonder",
+    "Great White Bonder 1": "GW Bonder",
+    "Great White Bonder 2": "GW Bonder",
+    "Great White Sub Bonder": "GW Bonder",
+    "H567 Hood Bonder": "H567 Bonder",
+    "H567 Ext Bonder": "H567 Bonder",
+}
+
 def load_workbook_data():
     wb = openpyxl.load_workbook(EXCEL_PATH)
     ws = wb.active
@@ -47,6 +58,29 @@ def load_workbook_data():
         data[name] = skills
 
     return wb, ws, headers, data
+
+
+def build_level_lookup(data):
+    """Return mapping of name -> {station -> level} with default 1."""
+    levels = {}
+
+    def resolve_level(skills, base):
+        """Find the first skill header that starts with the given base name."""
+        for h, lvl in skills.items():
+            if h.startswith(base):
+                return lvl
+        return 1
+
+    for name, skills in data.items():
+        per_station = {}
+        for st in STATIONS:
+            base = STATION_TO_HEADER.get(st)
+            if base:
+                per_station[st] = resolve_level(skills, base)
+            else:
+                per_station[st] = 1
+        levels[name] = per_station
+    return levels
 
 
 app = Flask(__name__)
@@ -126,8 +160,9 @@ def schedule():
     """Display a table of stations with a dropdown of workers for each."""
     _, _, _, data = load_workbook_data()
     names = sorted(data.keys())
+    levels = build_level_lookup(data)
     stations = list(enumerate(STATIONS))
-    return render_template("schedule.html", stations=stations, names=names)
+    return render_template("schedule.html", stations=stations, names=names, levels=levels)
 
 
 @app.route("/generate_schedule", methods=["POST"])
@@ -149,7 +184,9 @@ def view_schedule():
     schedule = session.get('last_schedule')
     if not schedule:
         return redirect(url_for('schedule'))
-    return render_template("generated_schedule.html", schedule=schedule)
+    _, _, _, data = load_workbook_data()
+    levels = build_level_lookup(data)
+    return render_template("generated_schedule.html", schedule=schedule, levels=levels)
 
 @app.route("/decrease", methods=["GET", "POST"])
 def decrease():

--- a/templates/generated_schedule.html
+++ b/templates/generated_schedule.html
@@ -16,10 +16,13 @@
       text-align: center;
     }
     .person-name {
-      background-color: #ffffff;
       padding: 4px;
       text-align: center;
     }
+    .level1 { background-color: #f8d7da; }
+    .level2 { background-color: #fff3cd; }
+    .level3 { background-color: #d4edda; }
+    .level4 { background-color: #c3e6cb; }
   </style>
   <h2>Generated Schedule</h2>
   <div class="schedule-grid">
@@ -27,7 +30,8 @@
     <div class="station-box">
       <div class="station-header">{{ station }}</div>
       {% for person in people %}
-      <div class="person-name">{{ person }}</div>
+      {% set lvl = levels.get(person, {}).get(station, 1) %}
+      <div class="person-name level{{ lvl }}">{{ person }}</div>
       {% endfor %}
     </div>
     {% endfor %}

--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -7,6 +7,10 @@
     .schedule-table select {
       width: 150px;
     }
+    .level1 { background-color: #f8d7da; }
+    .level2 { background-color: #fff3cd; }
+    .level3 { background-color: #d4edda; }
+    .level4 { background-color: #c3e6cb; }
   </style>
   <h2>Schedule</h2>
   {% if session.get('last_schedule') %}
@@ -34,7 +38,7 @@
           <select class="person-select" name="station{{ idx }}_{{ i }}">
             <option value="">-- Select --</option>
             {% for name in names %}
-              <option value="{{ name }}">{{ name }}</option>
+              <option value="{{ name }}" data-level="{{ levels[name][station] }}">{{ name }}</option>
             {% endfor %}
           </select>
         </td>
@@ -51,7 +55,22 @@
   <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
   <script>
     $(function(){
-      $('.person-select').select2();
+      var levelColors = {1:'#f8d7da',2:'#fff3cd',3:'#d4edda',4:'#c3e6cb'};
+
+      function formatState (state) {
+        if (!state.id) { return state.text; }
+        var level = $(state.element).data('level') || 1;
+        var $el = $('<span>' + state.text + '</span>');
+        $el.addClass('level'+level);
+        return $el;
+      }
+
+      function updateCellColor(select) {
+        var level = $(select).find('option:selected').data('level');
+        $(select).closest('td').css('background-color', levelColors[level] || '');
+      }
+
+      $('.person-select').select2({ templateResult: formatState, templateSelection: formatState });
 
       function updateOptions() {
         var selected = [];
@@ -74,7 +93,11 @@
         });
       }
 
-      $('.person-select').on('change', updateOptions);
+      $('.person-select').on('change', function(){
+        updateOptions();
+        updateCellColor(this);
+      });
+      $('.person-select').each(function(){ updateCellColor(this); });
       updateOptions();
 
       $('#generateLink').on('click', function(e){


### PR DESCRIPTION
## Summary
- show training level color for names on schedule page and generated schedule
- compute level mapping per station
- map select options to background color
- resolve training level headers by matching prefix

## Testing
- `pytest -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685bd7bb2e7c832fa2cc19327fe9a8dd